### PR TITLE
fix: also install livekit-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin handles the setup required for Expo projects to use the [LiveKit Rea
 ## Installation for managed Expo projects
 
 ```sh
-npx expo install @livekit/react-native @livekit/react-native-expo-plugin @livekit/react-native-webrtc @config-plugins/react-native-webrtc
+npx expo install livekit-client @livekit/react-native @livekit/react-native-expo-plugin @livekit/react-native-webrtc @config-plugins/react-native-webrtc
 ```
 
 ### Configure app.json


### PR DESCRIPTION
Since the React Native SDK marked the `livekit-client` dependency as peer dependency (https://github.com/livekit/client-sdk-react-native/releases/tag/v2.6.2), it needs to be install separately. However, the Expo plugin docs haven't been updated.